### PR TITLE
Add env variable to cp-ksql-server deployment for cp-schema-registry.url

### DIFF
--- a/charts/cp-ksql-server/templates/_helpers.tpl
+++ b/charts/cp-ksql-server/templates/_helpers.tpl
@@ -62,3 +62,20 @@ Default Server Pool Id to Release Name but allow it to be overridden
 {{- .Release.Name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified schema registry name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cp-ksql-server.cp-schema-registry.fullname" -}}
+{{- $name := default "cp-schema-registry" (index .Values "cp-schema-registry" "nameOverride") -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "cp-ksql-server.cp-schema-registry.service-name" -}}
+{{- if (index .Values "cp-schema-registry" "url") -}}
+{{- printf "%s" (index .Values "cp-schema-registry" "url") -}}
+{{- else -}}
+{{- printf "http://%s:8081" (include "cp-ksql-server.cp-schema-registry.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
             value: {{ template "cp-ksql-server.kafka.bootstrapServers" . }}
           - name: KSQL_KSQL_SERVICE_ID
             value: {{ template "cp-ksql-server.serviceId" . }}
+          - name: KSQL_KSQL_SCHEMA_REGISTRY_URL
+            value: {{ template "cp-ksql-server.cp-schema-registry.service-name" . }}
           {{- if .Values.ksql.headless }}
           - name: KSQL_KSQL_QUERIES_FILE
             value: /etc/ksql/queries/queries.sql


### PR DESCRIPTION
The option was present in the values file of the cp-ksql-server chart
but was not used.